### PR TITLE
don't need to monkey patch in to Capistrano::TaskEnhancements

### DIFF
--- a/lib/cap-ec2/capistrano.rb
+++ b/lib/cap-ec2/capistrano.rb
@@ -12,24 +12,27 @@ require_relative 'instance'
 # Load extra tasks
 load File.expand_path("../tasks/ec2.rake", __FILE__)
 
-# Monkey patch into Capistrano v3
-
 module Capistrano
-  module TaskEnhancements
+  module DSL
+    module Ec2
 
-    def ec2_handler
-      @ec2_handler ||= CapEC2::EC2Handler.new(env.fetch(:ec2_config, "config/ec2.yml"))
-    end
-    
-    def ec2_role(name, options={})
-      ec2_handler.get_servers_for_role(name).each do |server|
-        env.role(name, server.contact_point, options)
+      def ec2_handler
+        @ec2_handler ||= CapEC2::EC2Handler.new(env.fetch(:ec2_config, "config/ec2.yml"))
       end
-    end
     
-    def env
-      Configuration.env
-    end
+      def ec2_role(name, options={})
+        ec2_handler.get_servers_for_role(name).each do |server|
+          env.role(name, server.contact_point, options)
+        end
+      end
     
+      def env
+        Configuration.env
+      end
+    
+    end
   end
 end
+
+self.extend Capistrano::DSL::Ec2
+


### PR DESCRIPTION
hello!

You don't need to monkey patch into `Capistrano::TaskEnhancements` - you can extend the DSL like so:

``` ruby
module Capistrano
  module DSL
    module Ec2

      def ec2_handler
        @ec2_handler ||= CapEC2::EC2Handler.new(env.fetch(:ec2_config, "config/ec2.yml"))
      end

      ...

    end
  end
end

self.extend Capistrano::DSL::Ec2
```
