### PR TITLE
gracefully handle unnamed instances

### DIFF
--- a/lib/cap-ec2/status-table.rb
+++ b/lib/cap-ec2/status-table.rb
@@ -39,7 +39,7 @@ module CapEC2
     def instance_to_row(instance, index)
       [
         sprintf("%02d:", index),
-        instance.tags["Name"].green,
+        (instance.tags["Name"] || '').green,
         instance.id.red,
         instance.instance_type.cyan,
         instance.contact_point.blue.bold,


### PR DESCRIPTION
Instances don't need to have names, but then `bundle exec cap stage ec2:status` throws an `undefined method 'green' for nil:NilClass`
