### PR TITLE
Multiple Regions + questions

### DIFF
--- a/lib/cap-ec2/capistrano.rb
+++ b/lib/cap-ec2/capistrano.rb
@@ -16,7 +16,7 @@ module Capistrano
     module Ec2
 
       def ec2_handler
-        @ec2_handler ||= CapEC2::EC2Handler.new(env.fetch(:ec2_config, "config/ec2.yml"))
+        @ec2_handler ||= CapEC2::EC2Handler.new
       end
     
       def ec2_role(name, options={})

--- a/lib/cap-ec2/status-table.rb
+++ b/lib/cap-ec2/status-table.rb
@@ -2,9 +2,8 @@ module CapEC2
   class StatusTable
     include CapEC2::Utils
     
-    def initialize(instances, ec2_config)
+    def initialize(instances)
       @instances = instances
-      @ec2_config = ec2_config
       output
     end
     

--- a/lib/cap-ec2/tasks/ec2.rake
+++ b/lib/cap-ec2/tasks/ec2.rake
@@ -21,9 +21,15 @@ end
 namespace :load do
   task :defaults do
 
+    set :ec2_config, 'config/ec2.yml'
+
     set :ec2_project_tag, 'Project'
     set :ec2_roles_tag, 'Roles'
     set :ec2_stages_tag, 'Stages'
+    
+    set :ec2_access_key_id, nil
+    set :ec2_secret_access_key, nil
+    set :ec2_region, %w{}
 
   end
 end

--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -16,5 +16,30 @@ module CapEC2
       instance.public_dns_name || instance.public_ip_address || instance.private_ip_address
     end
     
+    def load_config
+      config_location = File.expand_path(fetch(:ec2_config), Dir.pwd) if fetch(:ec2_config)
+      if config_location && File.exists?(config_location)
+        config = YAML.load_file fetch(:ec2_config)
+        if config
+          set :ec2_project_tag, config['project_tag'] if config['project_tag']
+          set :ec2_roles_tag, config['roles_tag'] if config['roles_tag']
+          set :ec2_stages_tag, config['stages_tag'] if config['stages_tag']
+    
+          set :ec2_access_key_id, config['access_key_id'] if config['access_key_id']
+          set :ec2_secret_access_key, config['secret_access_key'] if config['secret_access_key']
+          set :ec2_region, config['regions'] if config['regions']
+        end
+      end
+    end
+    
+    def get_regions(regions_array=nil)
+      unless regions_array.empty?
+        return regions_array
+      else
+        @ec2 = ec2_connect
+        @ec2.regions.map(&:name)
+      end
+    end
+    
   end
 end


### PR DESCRIPTION
@andytinycat: I've got a couple of questions about some of the functionality in this gem, I'm going to propose some changes but I'm keen to retain backwards compatibility so I'd like to understand the supported use cases.
- You've got multiple regions here https://github.com/forward3d/cap-ec2/blob/master/lib/cap-ec2/ec2-handler.rb#L8 and https://github.com/forward3d/cap-ec2/blob/master/lib/cap-ec2/ec2-handler.rb#L69
  What's the use case for this?
- https://github.com/forward3d/cap-ec2/blob/master/lib/cap-ec2/capistrano.rb#L20 what the purpose of `ec2.yml` rather than defining these as Capistrano variables?

The AWS SDK out of the box supports credentials via ENV so currently if `config/ec2.yml` is blank (except for regions due to the lines mentioned above) and the AWS ENV exist they are used for the credentials. This is also how IAM roles work so they'd be supported too.

I keep all of my secrets in files `.env` files per stage and use [capistrano-env-config](https://github.com/rjocoleman/capistrano-env-config) to push them into the Capistrano environment to avoid pollution of the ENV and automatically manage different credentials per stage.

If you're open to it I'd like to submit a pull request that will:
1. Make `config/ec2.yml` optional (for backward compatibly)  and define `:access_key_id` and `:secret_access_key` as Capistrano variables. 
2. When listing instances iterate through all the regions available to the configured AWS account, rather than a pre-defined set.
3. Move the config for `stages_tag`, `roles_tag` and `project_tag` to Capistrano variables too.
