### PR TITLE
make the ec2 contact point configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ set :ec2_stages_tag, 'Stages'
 set :ec2_access_key_id, nil
 set :ec2_secret_access_key, nil
 set :ec2_region, %w{}
+set :ec2_contact_point, nil
 ```
 
 #### Order of inheritance
@@ -216,6 +217,22 @@ Example:
     Num  Name                          ID          Type      DNS              Zone        Roles         Stage
     00:  server-1-20131030-1144-0      i-abcdefgh  m1.small  192.168.202.248  us-west-2c  banana,apple  production
     01:  server-2-20131118-1839-0      i-hgfedcba  m1.small  192.168.200.60   us-west-2a  banana        production
+
+### DNS
+
+By default cap-EC2 will attempt to communicate with the ec2 instance using the following addresses (in order).
+
+1. Public DNS `:public_dns`
+2. Public IP `:public_ip`
+3. Private IP `:private_ip`
+
+This can be configured using the `set :ec2_contact_point`
+
+example
+
+```ruby
+set :ec2_contact_point, :private_ip
+```
 
 ### View server names
 

--- a/lib/cap-ec2/tasks/ec2.rake
+++ b/lib/cap-ec2/tasks/ec2.rake
@@ -31,7 +31,5 @@ namespace :load do
     set :ec2_secret_access_key, nil
     set :ec2_region, %w{}
 
-    set :ec2_contact_point, :public_dns_name
-
   end
 end

--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -1,5 +1,6 @@
 module CapEC2
   module Utils
+
     def project_tag
       fetch(:ec2_project_tag)
     end
@@ -12,8 +13,19 @@ module CapEC2
       fetch(:ec2_stages_tag)
     end
 
+    def self.contact_point_mapping
+      {
+        :public_dns => :public_dns_name,
+        :public_ip => :public_ip_address,
+        :private_ip => :private_ip_address
+      }
+    end
+
     def self.contact_point(instance)
-      instance.send(fetch(:ec2_contact_point))
+      ec2_interface = contact_point_mapping[fetch(:ec2_contact_point)]
+      return instance.send(ec2_interface) if ec2_interface
+
+      instance.public_dns_name || instance.public_ip_address || instance.private_ip_address
     end
 
     def load_config


### PR DESCRIPTION
Please note I have not tested this.  

Made the attribute that determines the contact point name onfigurable.  Will default to the public dns name.

Since this is now configurable I did away with the graceful degradation back to private ip
