### PR TITLE
Select running instances by state name instead of code

### DIFF
--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -62,7 +62,7 @@ module CapEC2
       @ec2.each do |_, ec2|
         instances = ec2.instances
           .filter(tag(project_tag), "*#{application}*")
-          .filter('instance-state-code', '16')
+          .filter('instance-state-name', 'running')
         servers << instances.select do |i|
           instance_has_tag?(i, roles_tag, role) &&
             instance_has_tag?(i, stages_tag, stage) &&


### PR DESCRIPTION
I've experienced a strange occurrence of the AWS SDK not including a running instance when filtered with instance-state-code=16, but it selected the instance when I changed the filter to using instance-state-name=running.

This change has the added benefit of making the code more readable as well by not having a magic number.

Reference: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeInstanceStatus.html
