### PR TITLE
Fix error from instance.tags[key] returning nil

### DIFF
--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -75,7 +75,7 @@ module CapEC2
     private
 
     def instance_has_tag?(instance, key, value)
-      instance.tags[key].split(',').map(&:strip).include?(value.to_s)
+      (instance.tags[key] || '').split(',').map(&:strip).include?(value.to_s)
     end
   end
 end


### PR DESCRIPTION
Rather than throwing an error, let's return false when the server doesn't have a tag.
