### PR TITLE
Use AWS.memoize

### DIFF
--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -12,6 +12,7 @@ module CapEC2
     end
 
     def ec2_connect(region=nil)
+      AWS.start_memoizing
       AWS::EC2.new(
         access_key_id: fetch(:ec2_access_key_id),
         secret_access_key: fetch(:ec2_secret_access_key),


### PR DESCRIPTION
cap-ec2 currently makes a request for every instance for every tag, which is kind of slow and awful if you have more than a couple of servers.

AWS.memoize fixes that rather nicely.
