### PR TITLE
Add `ec2_server` method to automatically add roles

### DIFF
--- a/lib/cap-ec2/capistrano.rb
+++ b/lib/cap-ec2/capistrano.rb
@@ -14,6 +14,7 @@ load File.expand_path("../tasks/ec2.rake", __FILE__)
 module Capistrano
   module DSL
     module Ec2
+      include CapEC2::Utils
 
       def ec2_handler
         @ec2_handler ||= CapEC2::EC2Handler.new
@@ -22,6 +23,13 @@ module Capistrano
       def ec2_role(name, options={})
         ec2_handler.get_servers_for_role(name).each do |server|
           env.role(name, CapEC2::Utils.contact_point(server), options)
+        end
+      end
+
+      def ec2_server(options={})
+        ec2_handler.get_servers.each do |server|
+          roles = server.tags[roles_tag] || ''
+          env.server(CapEC2::Utils.contact_point(server), options.merge(roles: roles.split(',')))
         end
       end
 

--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -59,14 +59,17 @@ module CapEC2
     end
 
     def get_servers_for_role(role)
+      get_servers.keep_if {|s| instance_has_tag?(s, roles_tag, role)}
+    end
+
+    def get_servers
       servers = []
       @ec2.each do |_, ec2|
         instances = ec2.instances
           .filter(tag(project_tag), "*#{application}*")
           .filter('instance-state-name', 'running')
         servers << instances.select do |i|
-          instance_has_tag?(i, roles_tag, role) &&
-            instance_has_tag?(i, stages_tag, stage) &&
+          instance_has_tag?(i, stages_tag, stage) &&
             instance_has_tag?(i, project_tag, application) &&
             (fetch(:ec2_filter_by_status_ok?) ? instance_status_ok?(i) : true)
         end


### PR DESCRIPTION
So, capistrano has two ways of adding hosts: the `role` method, and the `server` method. `server` allows you pass an array of roles with the options. However, the way capistrano stores references to hosts, if you call `role` twice with different roles, but the same host, it ignores the second call. So for servers tagged like so:

<table>
<tr>
<th>Role</th><th>Stage</th>
<tr>
<td>web,app</td><td>production</td>
</tr>
<tr>
<td>web,db</td><td>production</td>
</tr>
</table>

Calling `ec2_role` with the same options for the 3 different roles:

```ruby
%w(web app db).each do |role|
  ec2_role role, user: 'deploy', ssh_options: { auth_methods: %w(publickey) }
end
```

Results in `defined_roles` returning only `web`. If we change the order of the calls in this case to `app`, then `db`, then `web`, the `defined_roles` returns `app` and `db`, since they're different hosts. But `web` isn't added.

Perhaps this is a bug with capistrano itself, but we can get around it by defining an extra method `ec2_server` that only takes a list of options for connecting, and passes a list of roles automatically from the EC2 'roles' tag. This currently assumes that each role is connectable in the same way (which may not be desirable?), but it fits our use case.