### PR TITLE
Add `instance_status_ok?` method to fix problem connecting to unavailable instances

### DIFF
--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -68,7 +68,7 @@ module CapEC2
           instance_has_tag?(i, roles_tag, role) &&
             instance_has_tag?(i, stages_tag, stage) &&
             instance_has_tag?(i, project_tag, application) &&
-            instance_status_ok?(i)
+            (fetch(:ec2_filter_by_status_ok?) ? instance_status_ok?(i) : true)
         end
       end
       servers.flatten.sort_by {|s| s.tags["Name"]}

--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -40,6 +40,8 @@ module CapEC2
           set :ec2_access_key_id, config['access_key_id'] if config['access_key_id']
           set :ec2_secret_access_key, config['secret_access_key'] if config['secret_access_key']
           set :ec2_region, config['regions'] if config['regions']
+
+          set :ec2_filter_by_status_ok?, config['filter_by_status_ok?'] if config['filter_by_status_ok?']
         end
       end
     end


### PR DESCRIPTION
If an instance's status isn't `ok` (e.g. if it's still `initializing`), `cap-ec2` still tries to deploy to it, but we get this error:

```
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing on host ec2-xx-xx-xx-xx.compute-1.amazonaws.com: Connection refused - connect(2) for "ec2-xx-xx-xx-xx.compute-1.amazonaws.com" port 22
```

And we're prevented from deploying (or running any tasks) on the other `ok` servers.

This patch adds an `instance_status_ok?` method that checks the status, and we can filter out the servers that aren't yet reachable.
