### PR TITLE
Fixes #37 as proposed on AWS blog

### DIFF
--- a/cap-ec2.gemspec
+++ b/cap-ec2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "aws-sdk"
+  spec.add_dependency "aws-sdk-v1"
   spec.add_dependency "capistrano", ">= 3.0"
   spec.add_dependency "terminal-table"
   spec.add_dependency "colored"

--- a/lib/cap-ec2/capistrano.rb
+++ b/lib/cap-ec2/capistrano.rb
@@ -1,6 +1,6 @@
 require 'capistrano/setup'
 require 'capistrano/configuration'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'colored'
 require 'terminal-table'
 require 'yaml'


### PR DESCRIPTION
This is how Amazon proposes to update Gems on their bog post:

[http://ruby.awsblog.com/post/TxFKSK2QJE6RPZ/Upcoming-Stable-Release-of-AWS-SDK-for-Ruby-Version-2.](http://ruby.awsblog.com/post/TxFKSK2QJE6RPZ/Upcoming-Stable-Release-of-AWS-SDK-for-Ruby-Version-2.)