### PR TITLE
Removed require of capistrano/setup

### DIFF
--- a/lib/cap-ec2/capistrano.rb
+++ b/lib/cap-ec2/capistrano.rb
@@ -1,4 +1,3 @@
-require 'capistrano/setup'
 require 'capistrano/configuration'
 require 'aws-sdk-v1'
 require 'colorize'


### PR DESCRIPTION
`require capistrano/setup` I don't believe is needed here.

By removing it, we can make use of the capistrano-multiconfig gem, and (optionally) set the stage with `:stage` in the configuration (as alternative to relying on the filename, which would not work if using multiconfig). This allows us to use the following, which brings the benefit of better configuration management for multiple projects/stages.

`cap project:stage ec2:status`

Usage of the capistrano-multiconfig gem requires us to replace capistrano/setup with capistrano/multiconfig, which is carried out within the Capfile.
