### PR TITLE
Allow specifying a separate application name so that sub applications…

### DIFF
--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -51,7 +51,11 @@ module CapEC2
     end
 
     def application
-      Capistrano::Configuration.env.fetch(:application).to_s
+      appname = Capistrano::Configuration.env.fetch(:ec2_application).to_s
+      if appname.nil? || appname.length < 1
+        appname = Capistrano::Configuration.env.fetch(:application).to_s
+      end
+      appname
     end
 
     def tag(tag_name)


### PR DESCRIPTION
… can be deployed without having to change server tags. We have a use case where we build and deploy multiple, separate, applications as different directories within a single virtual host where we also have multiple hosts, e.g. the *Widget* application is deployed to the *Factory* host as http://www.factory.com/widget/ and the *Water* and *Fish* applications are deployed to the *Ocean* host as  http://www.ocean.com/water/ and http://www.ocean.com/fish/. 

In order to prevent the need for us to create a very long tag value (Tag Name=Projects, Tag Value=widget1,widget2,widget3,widget4, etc) we want to group the applications based on the host/domain name and not the application name. To accomplish this, we have created an override value called *ec2_application* which supersedes the *application* setting but *only* if it is set. 

This does not affect existing behavior because it defaults to using the normal **:application ** setting if the **:ec2_application** value is not set. My Ruby skills are only moderate, so please double check the *if ...* statement I wrote.

I tested this by doing the following:
# Test that **:application** value still works
## Configure Capistrano with only the **:application** value
## Configure a single server with the **Project** tag set to the **:application** value
## Run **cap dev ec2:status** --> the one server was returned (expected behavior)
# Test a missing **:ec2_application** shows no results
## Configure Capistrano with only the  **:application** value
## Configure a single server with the **Project** tag set to a value OTHER than the **:application** value
## Run **cap dev ec2:status** --> no results returned (the expected behavior)
# Test that **:ec2_application** value overrides the **:application** value
## Configure Capistrano with both the **:application** value AND the **:ec2_application** value
## Configure a single server with the **Project** tag set to the **:application** value
## Run **cap dev ec2:status** --> no results returned (the expected behavior)
## Configure Capistrano with both the **:application** value AND the **:ec2_application** value
## Configure a single server with the **Project** tag set to the **:ec2_application** value
## Run **cap dev ec2:status** --> one result returned (the expected behavior)