### PR TITLE
Allow instance_name env var to filter instances

### DIFF
--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -71,7 +71,8 @@ module CapEC2
             (fetch(:ec2_filter_by_status_ok?) ? instance_status_ok?(i) : true)
         end
       end
-      servers.flatten.sort_by {|s| s.tags["Name"] || ''}
+      servers.flatten.sort_by {|s| s.tags["Name"] || ''}.
+        select{|i| !ENV['instance_name'] || (ENV['instance_name'] == i.tags['Name'])}
     end
 
     def get_server(instance_id)


### PR DESCRIPTION
This patch allows instance filtering with an "instance_name" environment variable, so that you can deploy to a single instance.