### PR TITLE
Use ERB with ec2_config

### DIFF
--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -38,7 +38,7 @@ module CapEC2
     def load_config
       config_location = File.expand_path(fetch(:ec2_config), Dir.pwd) if fetch(:ec2_config)
       if config_location && File.exists?(config_location)
-        config = YAML.load_file fetch(:ec2_config)
+        config = YAML.load(ERB.new(File.read(fetch(:ec2_config))))
         if config
           set :ec2_project_tag, config['project_tag'] if config['project_tag']
           set :ec2_roles_tag, config['roles_tag'] if config['roles_tag']


### PR DESCRIPTION
It would be nice if we could use Ruby to set YAML keys with a default value. For example:

config/ec2.yml

```
project_tag: <%= ENV['CAP_EC2_TAG'] || 'project_name' %>
```

This way, if `CAP_EC2_TAG` is not set, then `cap-ec2` will default to using project_name for the `project_tag`.
