### PR TITLE
Upgrade to AWS's v2 SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,30 +50,36 @@ set :ec2_stages_tag, 'Stages'
 
 set :ec2_access_key_id, nil
 set :ec2_secret_access_key, nil
-set :ec2_region, %w{}
+set :ec2_region, %w{} # REQUIRED
 set :ec2_contact_point, nil
 
 set :ec2_filter_by_status_ok?, nil
 ```
 
 #### Order of inheritance
+
 `cap-ec2` supports multiple methods of configuration. The order of inheritance is:
 YAML File > User Capistrano Config > Default Capistrano Config > ENV variables.
 
 #### Regions
-`:ec2_region` is an array of [AWS regions](http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region), if not present all regions will be checked for matching instances - this the default behavior and can be slow, if speed is an issue consider setting your required regions.
 
-If`:ec2_access_key_id` or `:ec2_secret_access_key` are not set in any configuration the environment variables
-`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION` will be checked.
-If running on EC2 the IAM instance profile credentials will be used if credentials are not set by any other method.
+`:ec2_region` is an array of
+[AWS regions](http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region)
+and is required. Only list regions which you wish to query for
+instances; extra values simply slow down queries.
 
+If `:ec2_access_key_id` or `:ec2_secret_access_key` are not set in any
+configuration the environment variables `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY` and `AWS_REGION` will be checked and the
+default credential load order (including instance profiles
+credentials) will be honored.
 
 #### Misc settings
 
 * project_tag
 
-  Cap-EC2 will look for a tag with this name when searching for instances that belong to this project. 
-  Cap-EC2 will look for a value which matches the :application setting in your deploy.rb. 
+  Cap-EC2 will look for a tag with this name when searching for instances that belong to this project.
+  Cap-EC2 will look for a value which matches the :application setting in your deploy.rb.
   The tag name defaults to "Project" and must be set on your instances.
 
 * stages_tag

--- a/cap-ec2.gemspec
+++ b/cap-ec2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "aws-sdk-v1"
+  spec.add_dependency "aws-sdk", "~> 2.0"
   spec.add_dependency "capistrano", ">= 3.0"
   spec.add_dependency "terminal-table"
   spec.add_dependency "colorize"

--- a/lib/cap-ec2/status-table.rb
+++ b/lib/cap-ec2/status-table.rb
@@ -1,12 +1,12 @@
 module CapEC2
   class StatusTable
     include CapEC2::Utils
-    
+
     def initialize(instances)
       @instances = instances
       output
     end
-    
+
     def header_row
       [
         bold("Num"),
@@ -19,7 +19,7 @@ module CapEC2
         bold("Stages")
       ]
     end
-    
+
     def output
       table = Terminal::Table.new(
         :style => {
@@ -38,13 +38,13 @@ module CapEC2
     def instance_to_row(instance, index)
       [
         sprintf("%02d:", index),
-        green(instance.tags["Name"] || ''),
-        red(instance.id),
+        green(tag_value(instance, 'Name') || ''),
+        red(instance.instance_id),
         cyan(instance.instance_type),
         bold(blue(CapEC2::Utils.contact_point(instance))),
-        magenta(instance.availability_zone),
-        yellow(instance.tags[roles_tag]),
-        yellow(instance.tags[stages_tag])
+        magenta(instance.placement.availability_zone),
+        yellow(tag_value(instance, roles_tag)),
+        yellow(tag_value(instance, stages_tag))
       ]
     end
 
@@ -62,4 +62,3 @@ module CapEC2
 
   end
 end
-

--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -20,6 +20,10 @@ module CapEC2
       fetch(:ec2_stages_tag)
     end
 
+    def tag_value(instance, key)
+      instance.tags.find({}) { |t| t[:key] == key.to_s }[:value]
+    end
+
     def self.contact_point_mapping
       {
         :public_dns => :public_dns_name,
@@ -57,8 +61,7 @@ module CapEC2
       unless regions_array.nil? || regions_array.empty?
         return regions_array
       else
-        @ec2 = ec2_connect
-        @ec2.regions.map(&:name)
+        fail "You must specify at least one EC2 region."
       end
     end
 


### PR DESCRIPTION
A lot of structure has changed, so a lot if this is just updating how we
iterate over things. Notable elements include:
- Tags are now an array of key/value Hashes rather than a key value
  hash itself.
- Instance lists come inside reservation groups.

Also, the EC2 client no longer defaults to looking at every region by
default. You have to tell it a region for its query endpoint, forcing me
to make :ec2_region required.
