### PR TITLE
Add support for ec2_filters

### DIFF
--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -60,10 +60,7 @@ module CapEC2
     end
 
     def default_filter
-      {
-        tag(project_tag) => "*#{application}*",
-        'instance-state-name' => "running"
-      }
+      { tag(project_tag) => "*#{application}*" }
     end
 
     def tag(tag_name)


### PR DESCRIPTION
I've been finding myself needing ways to more specifically target classes of machines in my EC2 deploy, so I hacked this into my own copy of cap-ec2. The idea is that rather than specifying application and stage tags, you can provide your own list of filters. That is:

    set :ec2_filters, { "tag:Project" => "*foo"*, "tag:Stages" => fetch(:stage) }

is functionally equivalent to the existing setup. However, I can also customize it:

    set :ec2_filters, { "tag:Project" => "*foo"*, "tag:Stages" => fetch(:stage), "instance-type" => ["r3.xlarge" "r3.2xlarge"] }

Role filtering still applies with the previous strategy regardless (as Cap is pretty directly tied to the idea of roles).

I can compose an arbitrary set of filters to target specifically the machines I need to. It's been useful for me, and as a poweruser addition to the existing featureset, may find some use for other people too!