### PR TITLE
adding handler method and cap task to return host IPs

### DIFF
--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -42,6 +42,16 @@ module CapEC2
                    .join("\n")
     end
 
+    def host_ips(roles=nil)
+      host_ips = []
+      roles = [ roles ] if ( roles && ! roles.is_a?(Array) )
+      roles = defined_roles if roles.nil?
+      roles.map {|r| get_servers_for_role(r)}.flatten.uniq {|i| i.instance_id}.each do |i|
+        host_ips << CapEC2::Utils.contact_point(i)
+      end
+      host_ips
+    end
+
     def defined_roles
       roles(:all).flat_map(&:roles_array).uniq.sort
     end

--- a/lib/cap-ec2/tasks/ec2.rake
+++ b/lib/cap-ec2/tasks/ec2.rake
@@ -15,6 +15,12 @@ namespace :ec2 do
     ec2_handler.instance_ids
   end
 
+  desc "Show EC2 host_ips that match this project, optional filter for cap role: ec2:host_ips[<role>]"
+  task :host_ips, :role do |_t, args|
+    roles = args[:role] ? [ args[:role] ] : [:app, :web, :db]
+    puts ec2_handler.host_ips(roles)
+  end
+
 end
 
 


### PR DESCRIPTION
enables this kind of usage cap stage deploy configs:

```
role :app, ec2_handler.host_ips(:app)
role :db, ec2_handler.host_ips(:db), :primary => true, :source => true
```
