### PR TITLE
EC2 instance tags are available as parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Cap-EC2 changelog
 
+## 1.0.1
+
+Added the possibility to get any tags defined on EC2 instance as parameters in Capistrano.
+Updated AWS-SDK to Ver 2.
+
 ## 1.0.0
 
 Cap-EC2 is pretty stable, and the rate of PRs has decreased, so I've
@@ -28,7 +33,7 @@ decided to bump the version to 1.0.0.
 
 ## 0.0.15
 
-* Add `ec2_filter_by_status_ok?` to filter out instances that aren't returning `OK` 
+* Add `ec2_filter_by_status_ok?` to filter out instances that aren't returning `OK`
   for their EC2 status checks. [@tomconroy](https://github.com/tomconroy)
 
 ## 0.0.14

--- a/cap-ec2.gemspec
+++ b/cap-ec2.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "aws-sdk-v1"
+  spec.add_dependency "aws-sdk"
+  spec.add_dependency "aws-sdk-resources"
   spec.add_dependency "capistrano", ">= 3.0"
   spec.add_dependency "terminal-table"
   spec.add_dependency "colorize"

--- a/lib/cap-ec2/capistrano.rb
+++ b/lib/cap-ec2/capistrano.rb
@@ -20,8 +20,11 @@ module Capistrano
 
       def ec2_role(name, options={})
         ec2_handler.get_servers_for_role(name).each do |server|
-          env.role(name, CapEC2::Utils.contact_point(server),
-                   options_with_instance_id(options, server))
+          env.role(
+            name,
+            CapEC2::Utils.contact_point(server),
+            options_with_instance_id(options, server)
+          )
         end
       end
 
@@ -32,7 +35,10 @@ module Capistrano
       private
 
       def options_with_instance_id(options, server)
-        options.merge({aws_instance_id: server.instance_id})
+        tags = server[:tag_set].map{ |t| Hash[t[0].downcase.to_sym, t[1]] }.reduce({}, :merge)
+        options.merge({
+          aws_instance_id: server[:instance_id],
+        }).merge(tags)
       end
 
     end

--- a/lib/cap-ec2/status-table.rb
+++ b/lib/cap-ec2/status-table.rb
@@ -1,12 +1,12 @@
 module CapEC2
   class StatusTable
     include CapEC2::Utils
-    
+
     def initialize(instances)
       @instances = instances
       output
     end
-    
+
     def header_row
       [
         bold("Num"),
@@ -19,7 +19,7 @@ module CapEC2
         bold("Stages")
       ]
     end
-    
+
     def output
       table = Terminal::Table.new(
         :style => {
@@ -38,13 +38,13 @@ module CapEC2
     def instance_to_row(instance, index)
       [
         sprintf("%02d:", index),
-        green(instance.tags["Name"] || ''),
-        red(instance.id),
-        cyan(instance.instance_type),
+        green(instance[:tag_set]["Name"] || ''),
+        red(instance[:instance_id]),
+        cyan(instance[:instance_type]),
         bold(blue(CapEC2::Utils.contact_point(instance))),
-        magenta(instance.availability_zone),
-        yellow(instance.tags[roles_tag]),
-        yellow(instance.tags[stages_tag])
+        magenta(instance[:placement][:availability_zone]),
+        yellow(instance[:tag_set][roles_tag]),
+        yellow(instance[:tag_set][stages_tag])
       ]
     end
 

--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -31,8 +31,7 @@ module CapEC2
     def self.contact_point(instance)
       ec2_interface = contact_point_mapping[fetch(:ec2_contact_point)]
       return instance.send(ec2_interface) if ec2_interface
-
-      instance.public_dns_name || instance.public_ip_address || instance.private_ip_address
+      instance[:dns_name] || instance[:ip_address] || instance[:private_ip_address]
     end
 
     def load_config


### PR DESCRIPTION
Have added a possibility to get the tag - value pairs as parameters out of EC2 instance to Capistrano server parameters.