### PR TITLE
Require aws-sdk v2 instead of v1

### DIFF
--- a/lib/cap-ec2/capistrano.rb
+++ b/lib/cap-ec2/capistrano.rb
@@ -1,5 +1,5 @@
 require 'capistrano/configuration'
-require 'aws-sdk-v1'
+require 'aws-sdk'
 require 'colorize'
 require 'terminal-table'
 require 'yaml'


### PR DESCRIPTION
Fixes a runtime error caused by requiring an old version of `aws-sdk`