### PR TITLE
Allow using aws-sdk v3

### DIFF
--- a/cap-ec2.gemspec
+++ b/cap-ec2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "aws-sdk", "~> 2.0"
+  spec.add_dependency "aws-sdk", ">= 2.0"
   spec.add_dependency "capistrano", ">= 3.0"
   spec.add_dependency "terminal-table"
   spec.add_dependency "colorize"


### PR DESCRIPTION
AWS-SDK v3 is compatible with v2, so this should "just work," according to their documentation: https://github.com/aws/aws-sdk-ruby#upgrade-from-version-2

I just used this to successfully deploy one of our apps.