### PR TITLE
Requires aws-sdk-ec2 rather than aws-sdk

### DIFF
--- a/cap-ec2.gemspec
+++ b/cap-ec2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "aws-sdk", ">= 2.0"
+  spec.add_dependency "aws-sdk-ec2"
   spec.add_dependency "capistrano", ">= 3.0"
   spec.add_dependency "terminal-table"
   spec.add_dependency "colorize"

--- a/cap-ec2.gemspec
+++ b/cap-ec2.gemspec
@@ -5,7 +5,7 @@ require 'cap-ec2/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "cap-ec2"
-  spec.version       = CapEC2::VERSION
+  spec.version       = "1.1.3"
   spec.authors       = ["Andy Sykes", "Robert Coleman", "Forward3D Developers"]
   spec.email         = ["github@tinycat.co.uk", "github@robert.net.nz", "developers@forward3d.com"]
   spec.description   = %q{Cap-EC2 is used to generate Capistrano namespaces and tasks from Amazon EC2 instance tags, dynamically building the list of servers to be deployed to.}

--- a/lib/cap-ec2/capistrano.rb
+++ b/lib/cap-ec2/capistrano.rb
@@ -1,5 +1,5 @@
 require 'capistrano/configuration'
-require 'aws-sdk'
+require 'aws-sdk-ec2'
 require 'colorize'
 require 'terminal-table'
 require 'yaml'

--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -1,4 +1,4 @@
-equire 'aws-sdk-ec2'
+require 'aws-sdk-ec2'
 
 module CapEC2
   class EC2Handler

--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+equire 'aws-sdk-ec2'
 
 module CapEC2
   class EC2Handler

--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-ec2'
 
 module CapEC2
   module Utils

--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -55,7 +55,7 @@ module CapEC2
       end
 
       config_location = File.expand_path(fetch(:ec2_config), Dir.pwd) if fetch(:ec2_config)
-      if config_location && File.exists?(config_location)
+      if config_location && File.exist?(config_location)
         config = YAML.load(ERB.new(File.read(fetch(:ec2_config))))
         if config
           set :ec2_project_tag, config['project_tag'] if config['project_tag']


### PR DESCRIPTION
Related to issue https://github.com/forward3d/cap-ec2/issues/78

In pull request https://github.com/forward3d/cap-ec2/pull/76, a change was made to allow either AWS SDK v2 or v3 with `cap-ec2`.

However, the dependency on the `aws-sdk` v3 gem means that all other AWS gems get pulled in to the project, even if they are not desired.

In this PR, I make the required dependency be just on `aws-sdk-ec2`. For those using the AWS SDK v3, this can result in many gems no longer being needed just to run `cap-ec2`. 

However, this is a breaking change as it would mean `cap-ec2` will no longer work with AWS SDK v2. Merging this PR should probably require a major release increment for the gem.
