### PR TITLE
Support just profile

### DIFF
--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -14,9 +14,16 @@ module CapEC2
     end
 
     def ec2_connect(region=nil)
+      credentials = if fetch(:ec2_profile)
+        Aws::SharedCredentials.new(profile_name: fetch(:ec2_profile))
+      else
+        Aws::Credentials.new(
+          fetch(:ec2_access_key_id),
+          fetch(:ec2_secret_access_key),
+        )
+      end
       Aws::EC2::Client.new(
-        access_key_id: fetch(:ec2_access_key_id),
-        secret_access_key: fetch(:ec2_secret_access_key),
+        credentials: credentials,
         region: region
       )
     end

--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -46,14 +46,6 @@ module CapEC2
     end
 
     def load_config
-      if fetch(:ec2_profile)
-        credentials = Aws::SharedCredentials.new(profile_name: fetch(:ec2_profile)).credentials
-        if credentials
-          set :ec2_access_key_id, credentials.access_key_id
-          set :ec2_secret_access_key, credentials.secret_access_key
-        end
-      end
-
       config_location = File.expand_path(fetch(:ec2_config), Dir.pwd) if fetch(:ec2_config)
       if config_location && File.exists?(config_location)
         config = YAML.load(ERB.new(File.read(fetch(:ec2_config))))


### PR DESCRIPTION
"ec2_profile" param is extracted to "ec2_access_key_id" and "ec2_secret_access_key".
But other properties are also included in a profile.

This PR solve it with passing Aws::SharedCredentials created from "ec2_profile" to Aws::EC2::Client.